### PR TITLE
[Bugfix] Check relative URL instead of absolute

### DIFF
--- a/calendar-helper.js
+++ b/calendar-helper.js
@@ -1,6 +1,6 @@
 const handleMutations = (mutations) => {
 
-    if (window.location.href.indexOf('https://www.italki.com/booking/date') == -1) {
+    if (window.location.href.indexOf('booking/date') == -1) {
         return;
     }
 


### PR DESCRIPTION
It should work better in casae of any potential url structure changes in the future. The helper stopped working when the url was changed from https://www.italki.com/booking/date to https://www.italki.com/pl/booking/date